### PR TITLE
docs: update schema link

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -267,7 +267,7 @@ compliance checker:
   that the common AGE recovery key is present in all SOPS files, or that no PGP keys are used
   in any SOPS file.
 
-[config-schema]: schema.json
+[config-schema]: https://github.com/Bonial-International-GmbH/sops-check/blob/main/schema.json
 [gitleaks]: https://github.com/gitleaks/gitleaks
 [jsonschema-spec]: https://json-schema.org/draft/2020-12/json-schema-core
 [sarif]: https://sarifweb.azurewebsites.net/

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -1,1 +1,0 @@
-../schema.json


### PR DESCRIPTION
The existing link had two issues:

- Megalinter (specifically `prettier`) does not like the symlink and emits a warning.
- Since the old link was relative, it was dysfunctional in Backstage.