### PR TITLE
fix: copy missing files into image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,26 @@ jobs:
 
       - name: Run go vet
         run: make vet
+
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.2-alpine3.20 as builder
+FROM golang:1.23.2-alpine3.20 AS builder
 
 WORKDIR /src
 
@@ -7,11 +7,13 @@ RUN apk --update --no-cache add git make
 ENV CGO_ENABLED=0
 
 COPY go.mod go.mod
+COPY go.sum go.sum
 COPY Makefile Makefile
 
 RUN go mod download
 
 COPY *.go ./
+COPY internal internal/
 
 RUN make build
 


### PR DESCRIPTION
This also adds a docker-build job to the `ci` workflow to ensure we discover image build errors before attempting to create a release.