### PR TITLE
fix: do not include component name in tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
         "docs/",
         "mkdocs.yml"
       ],
+      "include-component-in-tag": false,
       "package-name": "sops-check"
     }
   },


### PR DESCRIPTION
https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#subsequent-versions

release-please created the tag `sops-check-v0.0.1`, but we actually want just `v0.0.1`.

The non-semver tag prevented `goreleaser` to create release binaries.