### PR TITLE
chore: fix changelog and markdownlint config

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -6,5 +6,6 @@ DISABLE:
 DISABLE_LINTERS:
   - GO_REVIVE # We're running revive via golangci-lint already.
 
-REPOSITORY_TRIVY_ARGUMENTS: --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --ignorefile .trivyignore.yaml
 EXCLUDED_DIRECTORIES: ["testdata"]
+MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: 'CHANGELOG\.md'
+REPOSITORY_TRIVY_ARGUMENTS: --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --ignorefile .trivyignore.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.0](https://github.com/Bonial-International-GmbH/sops-check/compare/v0.0.1...v0.1.0) (2024-11-29)
+## 0.1.0 (2024-11-29)
 
 
 ### Features
@@ -22,12 +22,3 @@
 * make megalinter happy ([60c82ba](https://github.com/Bonial-International-GmbH/sops-check/commit/60c82ba19e814abb8047f02d40a152e47a11791d))
 * run prettier ([1e23a8f](https://github.com/Bonial-International-GmbH/sops-check/commit/1e23a8f52b840d06edd1374d16c32567e4444388))
 * update version variable ([3e55502](https://github.com/Bonial-International-GmbH/sops-check/commit/3e555027d926b89e1673941c4eafc92494b049d8))
-
-## 0.0.1 (2024-11-29)
-
-
-### Features
-
-* add methods to find SOPS files ([#11](https://github.com/Bonial-International-GmbH/sops-check/issues/11)) ([61f0549](https://github.com/Bonial-International-GmbH/sops-check/commit/61f05497af13db4ff8275dc13e15f8bf62991d0c))
-* basic CLI implementation ([#15](https://github.com/Bonial-International-GmbH/sops-check/issues/15)) ([ef18cf2](https://github.com/Bonial-International-GmbH/sops-check/commit/ef18cf2a65eb227fc907dbc0973ea71a36bc285b))
-* implement rules engine ([#6](https://github.com/Bonial-International-GmbH/sops-check/issues/6)) ([d4345dd](https://github.com/Bonial-International-GmbH/sops-check/commit/d4345ddaa30681104b37e0f3ff1ae33aa5da9b35))


### PR DESCRIPTION
After the release `markdown-link-check` complained about a broken link, which pointed to the failed 0.0.1 release which does not exist.

https://github.com/Bonial-International-GmbH/sops-check/actions/runs/12085513612/job/33702910155

I removed the link from the changelog and also removed the section for the 0.0.1 version.

Additionally, I excluded `CHANGELOG.md` from `markdownlint` because it complains about reoccuring headlines like `Features` in there.