### PR TITLE
fix(release): check for `release_created == 'true'`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             ghcr.io/bonial-international-gmbh/sops-check
           tags: |
             type=sha
-            type=raw,value=${{ needs.release-please.outputs.tag_name }},enable=${{ needs.release-please.outputs.release_created }}
+            type=raw,value=${{ needs.release-please.outputs.tag_name }},enable=${{ needs.release-please.outputs.release_created == 'true' }}
             type=raw,value=latest
 
       - name: Build and push


### PR DESCRIPTION
The docs of the `release-please-action` state that `release_created` is `false` if no release was created.

https://github.com/googleapis/release-please-action?tab=readme-ov-file#root-component-outputs

This is incorrect, `release_created` is empty in this case. An empty string in the `enable` attribute leads to an `Invalid value` error:

https://github.com/Bonial-International-GmbH/sops-check/actions/runs/12117567635/job/33780291842

We'll explicitly compare `release_created` to `'true'` to make sure the result can only be `true` or `false`, but nothing else.