### PR TITLE
feat: add support for path-based rules

### DIFF
--- a/.sops-check.yaml
+++ b/.sops-check.yaml
@@ -2,3 +2,10 @@
 rules:
   - description: The AGE key used as part of the testdata
     match: age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw
+    paths:
+      - "*"
+      - "!demo/"
+  - description: Allow anything in the demo/ directory
+    matchRegex: ".*"
+    paths:
+      - "demo/"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,14 +19,16 @@ type Config struct {
 
 // Rule represents a single rule in the configuration.
 type Rule struct {
-	AllOf       []Rule `json:"allOf,omitempty"`
-	AnyOf       []Rule `json:"anyOf,omitempty"`
-	Match       string `json:"match,omitempty"`
-	MatchRegex  string `json:"matchRegex,omitempty"`
-	Not         *Rule  `json:"not,omitempty"`
-	OneOf       []Rule `json:"oneOf,omitempty"`
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url,omitempty"`
+	AllOf      []Rule `json:"allOf,omitempty"`
+	AnyOf      []Rule `json:"anyOf,omitempty"`
+	Match      string `json:"match,omitempty"`
+	MatchRegex string `json:"matchRegex,omitempty"`
+	Not        *Rule  `json:"not,omitempty"`
+	OneOf      []Rule `json:"oneOf,omitempty"`
+
+	Description string   `json:"description,omitempty"`
+	URL         string   `json:"url,omitempty"`
+	Paths       []string `json:"paths,omitempty"`
 }
 
 func isURL(str string) bool {

--- a/internal/rules/allof.go
+++ b/internal/rules/allof.go
@@ -18,11 +18,12 @@ func (*AllOfRule) Kind() Kind {
 
 // Eval implements Rule.
 func (r *AllOfRule) Eval(ctx *EvalContext) EvalResult {
-	result := evalRules(ctx, r.rules)
+	rules := ctx.filterRules(r.rules)
+	result := evalRules(ctx, rules)
 
 	return EvalResult{
 		Rule:      r,
-		Success:   result.successCount == len(r.rules),
+		Success:   result.successCount == len(rules),
 		Matched:   result.matched,
 		Unmatched: ctx.TrustAnchors.Difference(result.matched),
 		Nested:    result.results,

--- a/internal/rules/anyof.go
+++ b/internal/rules/anyof.go
@@ -18,7 +18,7 @@ func (*AnyOfRule) Kind() Kind {
 
 // Eval implements Rule.
 func (r *AnyOfRule) Eval(ctx *EvalContext) EvalResult {
-	result := evalRules(ctx, r.rules)
+	result := evalRules(ctx, ctx.filterRules(r.rules))
 
 	return EvalResult{
 		Rule:      r,

--- a/internal/rules/compile.go
+++ b/internal/rules/compile.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/Bonial-International-GmbH/sops-check/internal/config"
+	ignore "github.com/sabhiram/go-gitignore"
 )
 
 // Compile takes a slice of rule configurations and compiles it into a single
@@ -39,9 +40,15 @@ func compileRule(config config.Rule) (Rule, error) {
 		return nil, err
 	}
 
+	var pathMatcher *ignore.GitIgnore
+	if len(config.Paths) > 0 {
+		pathMatcher = ignore.CompileIgnoreLines(config.Paths...)
+	}
+
 	compiled.SetMeta(Meta{
 		Description: config.Description,
 		URL:         config.URL,
+		PathMatcher: pathMatcher,
 	})
 
 	return compiled, nil

--- a/internal/rules/oneof.go
+++ b/internal/rules/oneof.go
@@ -18,7 +18,7 @@ func (*OneOfRule) Kind() Kind {
 
 // Eval implements Rule.
 func (r *OneOfRule) Eval(ctx *EvalContext) EvalResult {
-	result := evalRules(ctx, r.rules)
+	result := evalRules(ctx, ctx.filterRules(r.rules))
 
 	return EvalResult{
 		Rule:      r,

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -2,6 +2,8 @@
 // rule types together with their rule evaluation logic.
 package rules
 
+import ignore "github.com/sabhiram/go-gitignore"
+
 // Meta describes metadata common to all available rules.
 type Meta struct {
 	// Description may contain the description of the rule. If the description
@@ -11,6 +13,18 @@ type Meta struct {
 	// explains the purpose of a rule. If non-empty, it is used to enrich error
 	// messages presented to the user.
 	URL string
+	// PathMatcher matches files this rule should apply to. If nil, the rule
+	// applies to all files.
+	PathMatcher *ignore.GitIgnore
+}
+
+// MatchesPath checks if a rule should be applied to the file at path.
+func (m Meta) MatchesPath(path string) bool {
+	if m.PathMatcher == nil {
+		return true
+	}
+
+	return m.PathMatcher.MatchesPath(path)
 }
 
 // Kind represents the kind of a rule.
@@ -57,6 +71,14 @@ func (r *metaRule) Meta() Meta {
 // SetMeta sets the rule metadata.
 func (r *metaRule) SetMeta(meta Meta) {
 	r.meta = meta
+}
+
+// withMeta sets the rule metadata and returns it.
+//
+// This function is just a convenience wrapper to all chaining.
+func withMeta(rule Rule, meta Meta) Rule {
+	rule.SetMeta(meta)
+	return rule
 }
 
 // Ensure that all rule types implement the Rule interface.

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -23,6 +23,7 @@ type testConfig struct {
 
 type testCase struct {
 	Description    string   `json:"description"`
+	FilePath       string   `json:"filePath"`
 	TrustAnchors   []string `json:"trustAnchors"`
 	ExpectSuccess  bool     `json:"expectSuccess"`
 	ExpectedOutput string   `json:"expectedOutput"`
@@ -79,7 +80,7 @@ func TestUI(t *testing.T) {
 			name := fmt.Sprintf("%s-%d", filepath.Base(path), i)
 
 			t.Run(name, func(t *testing.T) {
-				ctx := rules.NewEvalContext(testCase.TrustAnchors)
+				ctx := rules.NewEvalContext(testCase.FilePath, testCase.TrustAnchors)
 				result := rootRule.Eval(ctx)
 
 				assert.Equal(t, testCase.ExpectSuccess, result.Success)

--- a/internal/rules/testdata/ui/pathBased.yaml
+++ b/internal/rules/testdata/ui/pathBased.yaml
@@ -1,0 +1,80 @@
+---
+description: "pathBased"
+config: |
+  rules:
+    - allOf:
+        - match: production-key
+          paths:
+            - "**/production/"
+        - match: staging-key
+          paths:
+            - "**/staging/"
+        - match: dr-key
+        - anyOf:
+            - not:
+                match: bad-key
+                paths:
+                  - "**/bad/"
+            - not:
+                match: bad-key2
+              paths:
+                - "**/bad2/"
+testCases:
+  - description: "non-production and non-staging only requires dr-key"
+    trustAnchors: ["dr-key", "production-key", "staging-key"]
+    filePath: secret.yaml
+    expectSuccess: true
+    expectedOutput: |
+      Unmatched trust anchors:
+        - production-key
+        - staging-key
+  - description: "production requires dr-key and production-key"
+    trustAnchors: ["dr-key", "production-key", "staging-key"]
+    filePath: config/production/secret.yaml
+    expectSuccess: true
+    expectedOutput: |
+      Unmatched trust anchors:
+        - staging-key
+  - description: "staging requires dr-key and staging-key"
+    trustAnchors: ["dr-key", "production-key", "staging-key"]
+    filePath: config/staging/secret.yaml
+    expectSuccess: true
+    expectedOutput: |
+      Unmatched trust anchors:
+        - production-key
+  - description: "bad-key not allowed here"
+    trustAnchors: ["dr-key", "production-key", "bad-key"]
+    filePath: config/production/bad/secret.yaml
+    expectSuccess: false
+    expectedOutput: |
+      [allOf] Expected ALL of the nested rules to match, but found one failure:
+
+        1) [not] Expected nested rule to fail, but it did not:
+
+            1) [match] Matched trust anchors:
+                - bad-key
+
+      Unmatched trust anchors:
+        - bad-key
+  - description: "bad-key and bad-key2 not allowed here"
+    trustAnchors: ["dr-key", "production-key", "bad-key", "bad-key2"]
+    filePath: config/production/bad/bad2/secret.yaml
+    expectSuccess: false
+    expectedOutput: |
+      [allOf] Expected ALL of the nested rules to match, but found one failure:
+
+        1) [anyOf] Expected ANY of the nested rule to match, but none did:
+
+            1) [not] Expected nested rule to fail, but it did not:
+
+                1) [match] Matched trust anchors:
+                    - bad-key
+
+            2) [not] Expected nested rule to fail, but it did not:
+
+                1) [match] Matched trust anchors:
+                    - bad-key2
+
+      Unmatched trust anchors:
+        - bad-key
+        - bad-key2

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func checkFiles(w io.Writer, rootRule rules.Rule, cfg *config.Config, files []so
 }
 
 func checkFile(w io.Writer, rootRule rules.Rule, file *sops.File) rules.EvalResult {
-	ctx := rules.NewEvalContext(file.ExtractKeys())
+	ctx := rules.NewEvalContext(file.Path, file.ExtractKeys())
 	result := rootRule.Eval(ctx)
 	formattedResult := result.Format()
 

--- a/schema.json
+++ b/schema.json
@@ -2,6 +2,19 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "additionalProperties": false,
   "definitions": {
+    "paths": {
+      "items": {
+        "description": "A single path pattern. Paths are specified as gitignore pattern: https://git-scm.com/docs/gitignore",
+        "examples": [
+          "!docs/",
+          "/secrets.json",
+          ".deploy/**/*.sops.yaml"
+        ],
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
     "rule": {
       "additionalProperties": false,
       "description": "Defines a single matching rule.",
@@ -49,6 +62,10 @@
         "description": {
           "description": "Rule description displayed as context to the user.",
           "type": "string"
+        },
+        "paths": {
+          "$ref": "#/definitions/paths",
+          "description": "An optional list of path patterns this rule applies to."
         },
         "anyOf": {
           "$ref": "#/definitions/rules",


### PR DESCRIPTION
Rules can now define a optional list of `paths` they apply to. `paths` support the same syntax as entries in `.gitignore`.

It's valid to specify `paths` at any nesting level within the config.

The absense of `paths` makes evaluates a rule for any file as before, so this is a backwards compatible change.